### PR TITLE
Fix bug that happens while deleting temporary files on Windows

### DIFF
--- a/src/main/java/org/embulk/output/azure_blob_storage/AzureBlobStorageFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/azure_blob_storage/AzureBlobStorageFileOutputPlugin.java
@@ -222,10 +222,10 @@ public class AzureBlobStorageFileOutputPlugin
                                     log.info("Upload start {} to {}", file.getAbsolutePath(), filePath);
                                     blob.upload(new BufferedInputStream(new FileInputStream(file)), file.length());
                                     log.info("Upload completed {} to {}", file.getAbsolutePath(), filePath);
-                                    log.info("Delete completed local file {}", file.getAbsolutePath());
-                                    if (!file.delete()) {
-                                        throw new ConfigException("Couldn't delete local file " + file.getAbsolutePath());
+                                    if (file.exists() && !file.delete()) {
+                                        log.warn("Couldn't delete local file " + file.getAbsolutePath());
                                     }
+                                    log.info("Delete completed local file {}", file.getAbsolutePath());
                                     return null;
                                 }
 

--- a/src/main/java/org/embulk/output/azure_blob_storage/AzureBlobStorageFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/azure_blob_storage/AzureBlobStorageFileOutputPlugin.java
@@ -225,7 +225,6 @@ public class AzureBlobStorageFileOutputPlugin
                                     if (file.exists() && !file.delete()) {
                                         log.warn("Couldn't delete local file " + file.getAbsolutePath());
                                     }
-                                    log.info("Delete completed local file {}", file.getAbsolutePath());
                                     return null;
                                 }
 

--- a/src/main/java/org/embulk/output/azure_blob_storage/AzureBlobStorageFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/azure_blob_storage/AzureBlobStorageFileOutputPlugin.java
@@ -162,7 +162,7 @@ public class AzureBlobStorageFileOutputPlugin
                     suffix = "." + suffix;
                 }
                 filePath = pathPrefix + String.format(sequenceFormat, taskIndex, fileIndex) + suffix;
-                file = File.createTempFile(filePath, ".tmp");
+                file = Exec.getTempFileSpace().createTempFile(filePath, ".tmp");
                 log.info("Writing local file {}", file.getAbsolutePath());
                 output = new BufferedOutputStream(new FileOutputStream(file));
             }


### PR DESCRIPTION
Fix for https://github.com/embulk/embulk/issues/1051

This problem seems only happen at Windows env.
Somehow, `File.delete()` fails while deleting local temporary file.
I could reproduce this problem on AppVeyor
https://ci.appveyor.com/project/sakama/embulk-output-azure-blob-storage/builds/19601156

I added `File.exists()` before `File.delete()`.
I also updated code that plugin don't throw ConfigException even if fail to delete file because it isn't a critical failure and should be deleted automatically after Embulk run.
```
org.embulk.exec.PartialExecutionException: org.embulk.config.ConfigException: Couldn't delete local file c:\tmp\my-csv-000.00.csv8596539147105778010.tmp
        at org.embulk.exec.BulkLoader$LoaderState.buildPartialExecuteException(BulkLoader.java:339)
        at org.embulk.exec.BulkLoader.doRun(BulkLoader.java:565)
        at org.embulk.exec.BulkLoader.access$000(BulkLoader.java:34)
        at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:352)
        at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:349)
        at org.embulk.spi.Exec.doWith(Exec.java:22)
        at org.embulk.exec.BulkLoader.run(BulkLoader.java:349)
        at org.embulk.EmbulkEmbed.run(EmbulkEmbed.java:161)
        at org.embulk.EmbulkRunner.runInternal(EmbulkRunner.java:292)
        at org.embulk.EmbulkRunner.run(EmbulkRunner.java:156)
        at org.embulk.cli.EmbulkRun.runSubcommand(EmbulkRun.java:436)
        at org.embulk.cli.EmbulkRun.run(EmbulkRun.java:91)
        at org.embulk.cli.Main.main(Main.java:26)
Caused by: org.embulk.config.ConfigException: Couldn't delete local file c:\tmp\my-csv-000.00.csv8596539147105778010.tmp
        at org.embulk.output.azure_blob_storage.AzureBlobStorageFileOutputPlugin$AzureFileOutput$1.call(AzureBlobStorageFileOutputPlugin.java:227)
        at org.embulk.output.azure_blob_storage.AzureBlobStorageFileOutputPlugin$AzureFileOutput$1.call(AzureBlobStorageFileOutputPlugin.java:216)
        at org.embulk.spi.util.RetryExecutor.run(RetryExecutor.java:81)
        at org.embulk.spi.util.RetryExecutor.runInterruptible(RetryExecutor.java:62)
        at org.embulk.output.azure_blob_storage.AzureBlobStorageFileOutputPlugin$AzureFileOutput.uploadFile(AzureBlobStorageFileOutputPlugin.java:216)
        at org.embulk.output.azure_blob_storage.AzureBlobStorageFileOutputPlugin$AzureFileOutput.finish(AzureBlobStorageFileOutputPlugin.java:205)
        at org.embulk.spi.util.FileOutputOutputStream.close(FileOutputOutputStream.java:94)
        at sun.nio.cs.StreamEncoder.implClose(Unknown Source)
        at sun.nio.cs.StreamEncoder.close(Unknown Source)
        at java.io.OutputStreamWriter.close(Unknown Source)
        at java.io.BufferedWriter.close(Unknown Source)
        at org.embulk.spi.util.LineEncoder.finish(LineEncoder.java:90)
        at org.embulk.standards.CsvFormatterPlugin$1.finish(CsvFormatterPlugin.java:194)
        at org.embulk.spi.FileOutputRunner$DelegateTransactionalPageOutput.finish(FileOutputRunner.java:154)
        at org.embulk.exec.LocalExecutorPlugin$ScatterTransactionalPageOutput.finish(LocalExecutorPlugin.java:447)
        at org.embulk.spi.PageBuilder.finish(PageBuilder.java:228)
        at org.embulk.input.jdbc.AbstractJdbcInputPlugin.run(AbstractJdbcInputPlugin.java:493)
        at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor.runInputTask(LocalExecutorPlugin.java:271)
        at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor.access$000(LocalExecutorPlugin.java:196)
        at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor$1.call(LocalExecutorPlugin.java:235)
        at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor$1.call(LocalExecutorPlugin.java:232)
        at java.util.concurrent.FutureTask.run(Unknown Source)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
        at java.lang.Thread.run(Unknown Source)
        Suppressed: org.embulk.config.ConfigException: Couldn't delete local file c:\tmp\my-csv-001.00.csv9196116221386038964.tmp
                at org.embulk.output.azure_blob_storage.AzureBlobStorageFileOutputPlugin$AzureFileOutput$1.call(AzureBlobStorageFileOutputPlugin.java:227)
                at org.embulk.output.azure_blob_storage.AzureBlobStorageFileOutputPlugin$AzureFileOutput$1.call(AzureBlobStorageFileOutputPlugin.java:216)
                at org.embulk.spi.util.RetryExecutor.run(RetryExecutor.java:81)
                at org.embulk.spi.util.RetryExecutor.runInterruptible(RetryExecutor.java:62)
                at org.embulk.output.azure_blob_storage.AzureBlobStorageFileOutputPlugin$AzureFileOutput.uploadFile(AzureBlobStorageFileOutputPlugin.java:216)
                at org.embulk.output.azure_blob_storage.AzureBlobStorageFileOutputPlugin$AzureFileOutput.finish(AzureBlobStorageFileOutputPlugin.java:205)
                at org.embulk.spi.util.FileOutputOutputStream.close(FileOutputOutputStream.java:94)
                at sun.nio.cs.StreamEncoder.implClose(Unknown Source)
                at sun.nio.cs.StreamEncoder.close(Unknown Source)
                at java.io.OutputStreamWriter.close(Unknown Source)
                at java.io.BufferedWriter.close(Unknown Source)
                at org.embulk.spi.util.LineEncoder.close(LineEncoder.java:103)
                at org.embulk.standards.CsvFormatterPlugin$1.close(CsvFormatterPlugin.java:198)
                at org.embulk.spi.FileOutputRunner$DelegateTransactionalPageOutput.close(FileOutputRunner.java:159)
                at org.embulk.spi.CloseResource.close(CloseResource.java:25)
                at org.embulk.exec.LocalExecutorPlugin$ScatterTransactionalPageOutput.close(LocalExecutorPlugin.java:455)
                at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor.runInputTask(LocalExecutorPlugin.java:283)
                ... 7 more
```