### PR TITLE
Close BufferedInputStream before delete temporary file

### DIFF
--- a/src/main/java/org/embulk/output/azure_blob_storage/AzureBlobStorageFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/azure_blob_storage/AzureBlobStorageFileOutputPlugin.java
@@ -220,10 +220,14 @@ public class AzureBlobStorageFileOutputPlugin
                                     CloudBlobContainer container = client.getContainerReference(containerName);
                                     CloudBlockBlob blob = container.getBlockBlobReference(filePath);
                                     log.info("Upload start {} to {}", file.getAbsolutePath(), filePath);
-                                    blob.upload(new BufferedInputStream(new FileInputStream(file)), file.length());
-                                    log.info("Upload completed {} to {}", file.getAbsolutePath(), filePath);
-                                    if (file.exists() && !file.delete()) {
-                                        log.warn("Couldn't delete local file " + file.getAbsolutePath());
+                                    try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(file))) {
+                                        blob.upload(in, file.length());
+                                        log.info("Upload completed {} to {}", file.getAbsolutePath(), filePath);
+                                    }
+                                    if (file.exists()) {
+                                        if (!file.delete()) {
+                                            log.warn("Couldn't delete local file " + file.getAbsolutePath());
+                                        }
                                     }
                                     return null;
                                 }

--- a/src/main/java/org/embulk/output/azure_blob_storage/AzureBlobStorageFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/azure_blob_storage/AzureBlobStorageFileOutputPlugin.java
@@ -162,7 +162,7 @@ public class AzureBlobStorageFileOutputPlugin
                     suffix = "." + suffix;
                 }
                 filePath = pathPrefix + String.format(sequenceFormat, taskIndex, fileIndex) + suffix;
-                file = Exec.getTempFileSpace().createTempFile(filePath, ".tmp");
+                file = Exec.getTempFileSpace().createTempFile(filePath, "tmp");
                 log.info("Writing local file {}", file.getAbsolutePath());
                 output = new BufferedOutputStream(new FileOutputStream(file));
             }


### PR DESCRIPTION
Follow up for #12 

At #12, I added some fix to solve temporary file deletion failure on Windows.
I noticed I forget to close `BufferedInputStream` before delete temporary file.
That is the root cause to fail to delete file.

I confirmed "Couldn't delete local file" doesn't appear with this fix.
https://ci.appveyor.com/project/sakama/embulk-output-azure-blob-storage/builds/19628881