### PR TITLE
Catchup embulk 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.1 - 2022-03-30
+* [maintenance] Remove deprecated functions [#21](https://github.com/embulk/embulk-output-azure_blob_storage/pull/21)
+
 ## 0.1.11 - 2022-12-09
 * [maintenance] catch up with embulk 0.10.29 [#18](https://github.com/embulk/embulk-output-azure_blob_storage/pull/18)
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ targetCompatibility = 1.8
 
 group = "org.embulk"
 description = "Dumps records to Microsoft Azure Blob Storage."
-version = "0.2.0-SNAPSHOT"
+version = "0.2.1-SNAPSHOT"
 
 def embulkVersion = '0.10.29'
 
@@ -207,6 +207,10 @@ checkstyleTest {
 task checkstyle(type: Checkstyle) {
     classpath = sourceSets.main.output + sourceSets.test.output
     source = sourceSets.main.allJava + sourceSets.test.allJava
+}
+tasks.withType(JavaCompile) {
+    options.compilerArgs << "-Xlint:deprecation" << "-Xlint:unchecked"
+    options.encoding = "UTF-8"
 }
 
 jacocoTestReport {

--- a/src/main/java/org/embulk/output/azure_blob_storage/AzureBlobStorageFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/azure_blob_storage/AzureBlobStorageFileOutputPlugin.java
@@ -5,8 +5,6 @@ import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.BlobType;
 import com.microsoft.azure.storage.blob.CloudBlobClient;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
-import com.microsoft.azure.storage.blob.CloudBlockBlob;
-
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
@@ -14,24 +12,18 @@ import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
 import org.embulk.spi.Exec;
 import org.embulk.spi.FileOutputPlugin;
-import org.embulk.spi.TempFileSpace;
 import org.embulk.spi.TransactionalFileOutput;
-
 import org.embulk.util.config.Config;
 import org.embulk.util.config.ConfigDefault;
 import org.embulk.util.config.ConfigMapper;
 import org.embulk.util.config.ConfigMapperFactory;
 import org.embulk.util.config.Task;
-import org.embulk.util.retryhelper.RetryGiveupException;
-import org.embulk.util.retryhelper.Retryable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
 import java.util.List;
-
-import static org.embulk.util.retryhelper.RetryExecutor.retryExecutor;
 
 public class AzureBlobStorageFileOutputPlugin
         implements FileOutputPlugin
@@ -77,7 +69,6 @@ public class AzureBlobStorageFileOutputPlugin
         .addDefaultModules()
         .build();
     public static final ConfigMapper CONFIG_MAPPER = CONFIG_MAPPER_FACTORY.createConfigMapper();
-
 
     @Override
     public ConfigDiff transaction(ConfigSource config, int taskCount,

--- a/src/main/java/org/embulk/output/azure_blob_storage/BlobFileOutput.java
+++ b/src/main/java/org/embulk/output/azure_blob_storage/BlobFileOutput.java
@@ -120,10 +120,11 @@ public class BlobFileOutput implements TransactionalFileOutput
         }
 
         try {
-            return retryExecutor()
+            return RetryExecutor.builder()
                     .withRetryLimit(maxConnectionRetry)
-                    .withInitialRetryWait(500)
-                    .withMaxRetryWait(30 * 1000)
+                    .withInitialRetryWaitMillis(500)
+                    .withMaxRetryWaitMillis(30 * 1000)
+                    .build()
                     .runInterruptible(new Retryable<Void>() {
                         @Override
                         public Void call() throws StorageException, URISyntaxException, IOException

--- a/src/test/java/org/embulk/output/azure_blob_storage/TestAzureBlobStorageFileOutputPlugin.java
+++ b/src/test/java/org/embulk/output/azure_blob_storage/TestAzureBlobStorageFileOutputPlugin.java
@@ -1,26 +1,18 @@
 package org.embulk.output.azure_blob_storage;
 
 import com.google.common.collect.Lists;
-import org.embulk.config.ConfigDiff;
-import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskReport;
-import org.embulk.config.TaskSource;
 import org.embulk.formatter.csv.CsvFormatterPlugin;
 import org.embulk.input.file.LocalFileInputPlugin;
 import org.embulk.output.azure_blob_storage.AzureBlobStorageFileOutputPlugin.PluginTask;
 import org.embulk.parser.csv.CsvParserPlugin;
-import org.embulk.spi.Exec;
 import org.embulk.spi.FileInputPlugin;
 import org.embulk.spi.FileOutputPlugin;
 import org.embulk.spi.FileOutputRunner;
 import org.embulk.spi.FormatterPlugin;
-import org.embulk.spi.OutputPlugin;
 import org.embulk.spi.ParserPlugin;
 import org.embulk.spi.Schema;
-import org.embulk.spi.type.Type;
-import org.embulk.spi.type.Types;
-
 import org.embulk.test.TestingEmbulk;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -28,18 +20,14 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.net.URL;
-import java.nio.file.FileSystem;
 import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
-import java.util.List;
 
+import static org.embulk.output.azure_blob_storage.AzureBlobStorageFileOutputPlugin.CONFIG_MAPPER;
 import static org.embulk.output.azure_blob_storage.AzureBlobStorageFileOutputPlugin.CONFIG_MAPPER_FACTORY;
 import static org.embulk.output.azure_blob_storage.TestHelper.AZURE_ACCOUNT_KEY;
 import static org.embulk.output.azure_blob_storage.TestHelper.AZURE_ACCOUNT_NAME;
 import static org.embulk.output.azure_blob_storage.TestHelper.AZURE_CONTAINER;
-import static org.embulk.output.azure_blob_storage.TestHelper.Control;
-import static org.embulk.output.azure_blob_storage.TestHelper.LOCAL_PATH_PREFIX;
 import static org.embulk.output.azure_blob_storage.TestHelper.config;
 import static org.embulk.output.azure_blob_storage.TestHelper.deleteContainerIfExists;
 import static org.embulk.output.azure_blob_storage.TestHelper.formatterConfig;
@@ -48,8 +36,6 @@ import static org.embulk.output.azure_blob_storage.TestHelper.inputConfig;
 import static org.embulk.output.azure_blob_storage.TestHelper.isExistsContainer;
 import static org.embulk.output.azure_blob_storage.TestHelper.parserConfig;
 import static org.embulk.output.azure_blob_storage.TestHelper.schemaConfig;
-
-import static org.embulk.output.azure_blob_storage.AzureBlobStorageFileOutputPlugin.CONFIG_MAPPER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeNotNull;

--- a/src/test/java/org/embulk/output/azure_blob_storage/TestBlobFileOutput.java
+++ b/src/test/java/org/embulk/output/azure_blob_storage/TestBlobFileOutput.java
@@ -2,13 +2,10 @@ package org.embulk.output.azure_blob_storage;
 
 import com.google.common.collect.ImmutableList;
 import org.embulk.EmbulkSystemProperties;
-import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigSource;
 import org.embulk.formatter.csv.CsvFormatterPlugin;
 import org.embulk.input.file.LocalFileInputPlugin;
 import org.embulk.parser.csv.CsvParserPlugin;
-import org.embulk.spi.Buffer;
-import org.embulk.spi.Exec;
 import org.embulk.spi.FileInputPlugin;
 import org.embulk.spi.FileOutputPlugin;
 import org.embulk.spi.FileOutputRunner;
@@ -21,9 +18,6 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.file.Paths;
@@ -35,13 +29,9 @@ import static org.embulk.output.azure_blob_storage.TestHelper.AZURE_ACCOUNT_KEY;
 import static org.embulk.output.azure_blob_storage.TestHelper.AZURE_ACCOUNT_NAME;
 import static org.embulk.output.azure_blob_storage.TestHelper.AZURE_CONTAINER;
 import static org.embulk.output.azure_blob_storage.TestHelper.AZURE_PATH_PREFIX;
-import static org.embulk.output.azure_blob_storage.TestHelper.LOCAL_PATH_PREFIX;
 import static org.embulk.output.azure_blob_storage.TestHelper.config;
-import static org.embulk.output.azure_blob_storage.TestHelper.convertInputStreamToByte;
 import static org.embulk.output.azure_blob_storage.TestHelper.getFileContentsFromAzure;
-import static org.embulk.output.azure_blob_storage.TestHelper.getSchema;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeNotNull;
 

--- a/src/test/java/org/embulk/output/azure_blob_storage/TestBlockBlobFileOutput.java
+++ b/src/test/java/org/embulk/output/azure_blob_storage/TestBlockBlobFileOutput.java
@@ -1,25 +1,18 @@
 package org.embulk.output.azure_blob_storage;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
-import com.microsoft.azure.storage.blob.BlobType;
 import com.microsoft.azure.storage.blob.CloudBlobClient;
 import org.embulk.EmbulkSystemProperties;
-import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigSource;
-import org.embulk.config.TaskReport;
-import org.embulk.config.TaskSource;
 import org.embulk.formatter.csv.CsvFormatterPlugin;
 import org.embulk.input.file.LocalFileInputPlugin;
 import org.embulk.parser.csv.CsvParserPlugin;
 import org.embulk.spi.Buffer;
-import org.embulk.spi.Exec;
 import org.embulk.spi.FileInputPlugin;
 import org.embulk.spi.FileOutputPlugin;
 import org.embulk.spi.FileOutputRunner;
 import org.embulk.spi.FormatterPlugin;
-import org.embulk.spi.OutputPlugin;
 import org.embulk.spi.ParserPlugin;
 import org.embulk.spi.Schema;
 import org.embulk.spi.TempFileSpace;
@@ -29,31 +22,24 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.FileInputStream;
-import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Field;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Properties;
 
 import static org.embulk.output.azure_blob_storage.AzureBlobStorageFileOutputPlugin.CONFIG_MAPPER;
-import static org.embulk.output.azure_blob_storage.AzureBlobStorageFileOutputPlugin.CONFIG_MAPPER_FACTORY;
 import static org.embulk.output.azure_blob_storage.TestHelper.AZURE_ACCOUNT_KEY;
 import static org.embulk.output.azure_blob_storage.TestHelper.AZURE_ACCOUNT_NAME;
 import static org.embulk.output.azure_blob_storage.TestHelper.AZURE_CONTAINER;
 import static org.embulk.output.azure_blob_storage.TestHelper.AZURE_PATH_PREFIX;
-import static org.embulk.output.azure_blob_storage.TestHelper.Control;
 import static org.embulk.output.azure_blob_storage.TestHelper.config;
 import static org.embulk.output.azure_blob_storage.TestHelper.convertInputStreamToByte;
 import static org.embulk.output.azure_blob_storage.TestHelper.getFileContentsFromAzure;
-import static org.embulk.output.azure_blob_storage.TestHelper.getSchema;
 import static org.embulk.output.azure_blob_storage.TestHelper.newAzureClient;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeNotNull;
 
 public class TestBlockBlobFileOutput

--- a/src/test/java/org/embulk/output/azure_blob_storage/TestHelper.java
+++ b/src/test/java/org/embulk/output/azure_blob_storage/TestHelper.java
@@ -29,7 +29,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.embulk.output.azure_blob_storage.AzureBlobStorageFileOutputPlugin.CONFIG_MAPPER_FACTORY;
-import static org.junit.Assume.assumeNotNull;
 
 public class TestHelper
 {


### PR DESCRIPTION
Catchup embulk 10 including

- Replace Exec.newTaskReport() 
- Replace retryExecutor()
- remove un-use imports
- fix import order